### PR TITLE
Fix wrapping with 3 lines or more

### DIFF
--- a/balance-text.js
+++ b/balance-text.js
@@ -49,7 +49,18 @@ const calcContentLength = element => {
 }
 
 const countLines = element => {
-    return Math.ceil(element.contentLength / element.width)
+    let lines = 1;
+    let currentLineLength = 0;
+    if (element.width <= element.contentLength) return lines;
+    for (let i = 0; i < element.wordsLengths.length; i++) {
+        const currentWordLength = element.wordsLengths[i];
+        if (currentLineLength + currentWordLength > element.width) {
+            lines++;
+            currentLineLength = 0;
+        }
+        currentLineLength += currentWordLength + element.space;
+    }
+    return lines;
 }
 
 const getDimensionsOfEveryElement = elements => {
@@ -140,13 +151,12 @@ const createOptimalLineBreaks = elementsArray => {
                 for (let i = 0; i < element.wordsLengths.length; i++) {
                     const currentWordLength = element.wordsLengths[i]
                     if (currentLineLength + currentWordLength > testLineLength) {
-                        newHTML += '<br>' + element.words[i] + ' '
+                        newHTML += '<br>';
                         currentLineLength = 0
                         totalLineBreaks++
-                    } else {
-                        newHTML += element.words[i] + ' '
-                        currentLineLength += currentWordLength + element.space
                     }
+                    newHTML += element.words[i] + ' '
+                    currentLineLength += currentWordLength + element.space
                 }
                 if (totalLineBreaks <= element.lines) {
                     element.element.innerHTML = newHTML


### PR DESCRIPTION
The current line length is set to 0 from the second line while it should be set to the current word length plus space instead.

Moreover, the theoritical number of lines is computed too naively: it does not take wrapping constraints into consideration. Instead, compute the number of line breaking when trying to wrap in a classic way.